### PR TITLE
fix: use globalthis instead of window object for webworker compat

### DIFF
--- a/index-browser.js
+++ b/index-browser.js
@@ -2,12 +2,13 @@
 const { Buffer } = require('buffer')
 const ci = require('@ipld/codec-interface')
 const multicodec = require('multicodec')
+const globalThis = require('globalthis')()
 
-if (!window.codecCache) {
-  window.codecCache = {}
+if (!globalThis.codecCache) {
+  globalThis.codecCache = {}
 }
 
-const cache = window.codecCache
+const cache = globalThis.codecCache
 
 const _convert = c => ci.create(c.util.serialize, c.util.deserialize, multicodec.print[c.codec])
 const toBuffer = b => Buffer.isBuffer(b) ? b : Buffer.from(b)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ipld/codec-interface": "^1.0.5",
     "@ipld/dag-json": "^2.0.4",
     "buffer": "^5.5.0",
+    "globalthis": "^1.0.1",
     "ipld-bitcoin": "~0.3.0",
     "ipld-dag-cbor": "~0.15.0",
     "ipld-dag-pb": "~0.18.1",


### PR DESCRIPTION
The `window` global is not available in webworkers.

This module fails with this sort of error:

```
Chrome Headless 84.0.4147.105 (Mac OS 10.15.6) ERROR
  [karma-mocha-webworker] RPCRequestError<ReferenceError>: window is not defined at RPCRequestError<ReferenceError>: window is not defined
      at node_modules/karma-mocha-webworker/karma-mocha-webworker-client/adapter.js:4234:57
  Caused by Remote ReferenceError: window is not defined
      at eval (file:/Users/alex/Documents/Workspaces/ipld/js-get-codec/index-browser.js:12:1)
      at Object../index-browser.js (tests/test-get-codec.js:98:1)
      at __webpack_require__ (tests/test-get-codec.js:21:30)
      at eval (file:/Users/alex/Documents/Workspaces/ipld/js-get-codec/tests/test-get-codec.js:4:18)
      at Object../tests/test-get-codec.js (tests/test-get-codec.js:1644:1)
      at __webpack_require__ (tests/test-get-codec.js:21:30)
      at tests/test-get-codec.js:85:18
      at tests/test-get-codec.js:88:10
      at Object.importScripts (node_modules/karma-mocha-webworker/karma-mocha-webworker-client/worker.js:109:47)
      at node_modules/karma-mocha-webworker/karma-mocha-webworker-client/worker.js:3400:35
```

This PR adds the [globalthis](https://www.npmjs.com/package/globalthis) module as a dep to access `codecCache` in a webworker without exploding.